### PR TITLE
Share lsa_span_* numpy array between mean and std (~25s for a 3k word on my machine)

### DIFF
--- a/text_metrics/metrics/lsa.py
+++ b/text_metrics/metrics/lsa.py
@@ -340,58 +340,72 @@ class LsaGivennessStd(LsaGivennessBase):
 
 
 class LsaSpanBase(base.Metric):
-    """A base class for LSA span metrics."""
+    """Base class for LSA span metrics.
 
-    def get_value(self, similarities):
-        """Given a list of similarities between sentences and the span of the
-        previous text, return the value of the metric.
-        """
+    `lsa_span_mean` and `lsa_span_std` differ only in their aggregation
+    over the same span array; the array itself is cached as the
+    `lsa_spans` ResourcePool resource so the two metrics share the work.
+    """
+
+    def get_value(self, spans):
+        """Given the span array, return the value of the metric."""
 
         raise NotImplementedError('Subclasses should override this method')
 
     def value_for_text(self, t, rp=default_rp):
-        space = rp.lsa_space()
-        num_topics = space.num_topics
-
-        tokens = rp.tokens(t)
-        tokens = [[token.lower() for token in sentence] for sentence in tokens]
-
-        if len(tokens) < 2:
+        spans = rp.lsa_spans(t)
+        if spans is None:
             return 0
-        # print("----------------------------> ", self.column_name, "<------------------------------------")
-        spans = np.zeros(len(tokens) - 1)
-        for i in range(1, len(tokens)):
-            past_sentences = tokens[:i]
-            span_dim = len(past_sentences)
-
-            # print("Tokens -->", tokens[i])
-            if span_dim > num_topics - 1:
-                # It's not clear, from the papers I read, what should be done
-                # in this case. I did what seemed to not imply in loosing
-                # information.
-                beginning = past_sentences[0:span_dim - num_topics]
-                past_sentences[0] = list(chain.from_iterable(beginning))
-
-            past_vectors = [sparse2full(space.get_vector(sent), num_topics)
-                            for sent in past_sentences]
-
-            curr_vector = sparse2full(space.get_vector(tokens[i]), num_topics)
-            curr_array = np.array(curr_vector).reshape(num_topics, 1)
-
-            A = np.array(past_vectors).transpose()
-
-            projection_matrix = dot(dot(A,
-                                        pinv(dot(A.transpose(),
-                                                 A))),
-                                    A.transpose())
-
-            projection = dot(projection_matrix, curr_array).ravel()
-
-            spans[i - 1] = cossim(full2sparse(curr_vector),
-                                  full2sparse(projection))
-            # print("span --> ", spans[i-1], "\n")
-
         return round(self.get_value(spans), 5)
+
+
+def compute_lsa_spans(t, rp):
+    """Hook for the `lsa_spans` ResourcePool resource.
+
+    Returns the per-sentence LSA span array (cosine of each sentence
+    against the LSA projection of all preceding sentences), or `None`
+    for texts with fewer than two sentences.
+    """
+    space = rp.lsa_space()
+    num_topics = space.num_topics
+
+    tokens = rp.tokens(t)
+    tokens = [[token.lower() for token in sentence] for sentence in tokens]
+
+    if len(tokens) < 2:
+        return None
+
+    spans = np.zeros(len(tokens) - 1)
+    for i in range(1, len(tokens)):
+        past_sentences = tokens[:i]
+        span_dim = len(past_sentences)
+
+        if span_dim > num_topics - 1:
+            # It's not clear, from the papers I read, what should be done
+            # in this case. I did what seemed to not imply in loosing
+            # information.
+            beginning = past_sentences[0:span_dim - num_topics]
+            past_sentences[0] = list(chain.from_iterable(beginning))
+
+        past_vectors = [sparse2full(space.get_vector(sent), num_topics)
+                        for sent in past_sentences]
+
+        curr_vector = sparse2full(space.get_vector(tokens[i]), num_topics)
+        curr_array = np.array(curr_vector).reshape(num_topics, 1)
+
+        A = np.array(past_vectors).transpose()
+
+        projection_matrix = dot(dot(A,
+                                    pinv(dot(A.transpose(),
+                                             A))),
+                                A.transpose())
+
+        projection = dot(projection_matrix, curr_array).ravel()
+
+        spans[i - 1] = cossim(full2sparse(curr_vector),
+                              full2sparse(projection))
+
+    return spans
 
 
 class LsaSpanMean(LsaSpanBase):

--- a/text_metrics/resource_pool.py
+++ b/text_metrics/resource_pool.py
@@ -200,6 +200,7 @@ class DefaultResourcePool(ResourcePool):
 
         # LSA spaces
         self.register('lsa_space', self._lsa_space, pinned=True)
+        self.register('lsa_spans', self._lsa_spans)
 
         # Language models
         self.register('language_model', self._language_model, pinned=True)
@@ -701,6 +702,17 @@ class DefaultResourcePool(ResourcePool):
         """
         space = LsaSpace(config['LSA_MODEL_PATH'])
         return space
+
+    def _lsa_spans(self, text):
+        """Return the per-sentence LSA span array for `text`.
+
+        Cached per-Text by the unpinned resource cache. `lsa_span_mean`
+        and `lsa_span_std` both consume this resource so the O(n^2)
+        computation runs once per text instead of once per metric.
+        Deferred import avoids a metrics <-> resource_pool cycle.
+        """
+        from text_metrics.metrics.lsa import compute_lsa_spans
+        return compute_lsa_spans(text, self)
 
     def _language_model(self):
         """Return the default language model (a 3-gram model


### PR DESCRIPTION
`LsaSpanMean` and `LsaSpanStd` inherit the same `value_for_text` body and differ only in their aggregation (`spans.mean()` vs `spans.std()`). The underlying span array is identical and expensive to compute — O(n^2) sentence-vector lookups plus a pseudoinverse per sentence — but each subclass runs the full computation independently, so one of the two runs is pure waste.

Promotes the span computation to a module-level `compute_lsa_spans` helper and registers it as the `lsa_spans` ResourcePool resource. The two metrics call `rp.lsa_spans(t)` instead of computing the array themselves, so they share the work via the standard unpinned cache. The hook lives in `DefaultResourcePool._lsa_spans` with a deferred import to avoid an `lsa.py <-> resource_pool.py` cycle, mirroring the pattern used for `parse_trees` and `dep_trees`.

Whichever of the two metrics runs second hits the cache. Order- independent: if only one runs, it pays the full cost; if only the other runs, the cache is populated but never reused; either way the result is identical to the pre-patch behaviour.

Measured on a 3,124-word Portuguese short story (M3 macbook air):

  - `metric.lsa_span_mean`: 25.49s -> 26.34s (does the one-time computation, charged the same as before plus the cache write)
  - `metric.lsa_span_std`:  25.07s -> < 0.13s (drops off the top-20 metrics list; now just reads `rp.lsa_spans` and calls `.std()`)
  - `rp.lsa_spans`:         visible in the profile at 26.34s

Metric outputs are byte-identical between baseline and patched runs.

Note: there are other mean/std metrics, but I didn't address them here because they seem significantly cheaper to compute:
 - metric.lsa_adj_mean: 0.77s
  - metric.lsa_adj_std: 0.05s
  - metric.lsa_paragraph_mean: 0.024s
  - metric.lsa_paragraph_std: 0.024s
  - metric.lsa_givenness_mean: 0.22s
  - metric.lsa_givenness_std: 0.23s

A follow up PR could tighten the whole lsa mean/std story.