### PR TITLE
Memoize DelafStemmer.get_lemma to avoid redundant DB queries

### DIFF
--- a/text_metrics/tools/stemmers.py
+++ b/text_metrics/tools/stemmers.py
@@ -21,22 +21,32 @@ import text_metrics.resource_pool
 
 class DelafStemmer(object):
 
-    """Docstring for DelafStemmer. """
+    """Stemmer backed by the `delaf_words` Postgres table.
+
+    Lemmas are deterministic given (word, pos), so results are memoized in a
+    process-wide dict to avoid redundant DB queries — every guten.py metric
+    re-stems the same content-word list, which on natural text drives many
+    tens of thousands of repeated lookups for the same handful of types.
+    """
 
     def __init__(self):
-        """@todo: to be defined1. """
-        pass
+        self._cache = {}
 
     def get_lemma(self, word, pos=None):
-
         if pos == "ADJ":
             pos = "A"
- 
+
         word = word.lower()
+        key = (word, pos)
 
-        delaf_word = text_metrics.resource_pool.rp.db_helper().get_delaf_word(word, pos)
+        if key in self._cache:
+            return self._cache[key]
 
+        helper = text_metrics.resource_pool.rp.db_helper()
+        delaf_word = helper.get_delaf_word(word, pos)
         if delaf_word is None:
-            delaf_word = text_metrics.resource_pool.rp.db_helper().get_delaf_word(word)
+            delaf_word = helper.get_delaf_word(word)
 
-        return delaf_word.lemma if delaf_word is not None else None
+        lemma = delaf_word.lemma if delaf_word is not None else None
+        self._cache[key] = lemma
+        return lemma


### PR DESCRIPTION
`get_lemma(word, pos)` is a deterministic map backed by the `delaf_words` Postgres table, but it does no caching, and every guten.py metric (`concretude_*`, `familiaridade_*`, `idade_aquisicao_*`, `imageabilidade_*` — ~30 metrics) re-stems the same content-word list independently. On a representative 3,122-word Portuguese book the same handful of word types drives 65,659 `get_delaf_word` calls, while only ~2,700 unique `(word, pos)` pairs exist in the text.

Adds an instance-level dict cache keyed by `(word, pos)` storing the resolved lemma string (not the SQLAlchemy ORM object — keeps the cache session-boundary-safe and minimal). Membership is checked with `in` rather than a `.get()` default, because `None` is itself a valid cached value (a word with no DELAF entry) and must not be treated as a miss. Because `DelafStemmer` is a pinned ResourcePool resource (`resource_pool.py:155`), there is exactly one instance per process, making the cache effectively process-wide.

Measured on the same 3,122-word book with the profiling instrumentation from the previous commit, atop `main`:

  - `db.get_delaf_word` calls: 65,659 → 2,696 (-96%)
  - `db.get_delaf_word` total time: 13.63s → 0.54s (-13.1s)
  - Total wall time: 112.68s → 98.97s (-12%)

Independently verified on top of the `split-palavras` branch, where the psycholinguistic GUTEN metrics that drive the redundant lookups are reachable from `no_palavras_metrics`:

  - Total wall time: 117.96s → 107.32s (-9.0%)
  - 152/152 metric values byte-identical between baseline and memoized runs; 0 None values either side.