### PR TITLE
Finish cohmetrix:focal -> cohmetrix:noble tag rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ From the repository root:
 $ ./build.sh
 ```
 
-This builds the `cohmetrix:focal` image using the local `Dockerfile`. From here you can run the full stack via `./run.sh` or use the pre-built Docker Hub image as described in the next section.
+This builds the `cohmetrix:noble` image using the local `Dockerfile`. From here you can run the full stack via `./run.sh` or use the pre-built Docker Hub image as described in the next section.
 
 ### Screencasts
 

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-docker run --rm --link pgs_cohmetrix:pgs_cohmetrix --link palavras:palavras -v "$SCRIPT_DIR":/opt/text_metrics cohmetrix:focal bash -c "python3 run_all.py \"$1\" \"$2\""
+docker run --rm --link pgs_cohmetrix:pgs_cohmetrix --link palavras:palavras -v "$SCRIPT_DIR":/opt/text_metrics cohmetrix:noble bash -c "python3 run_all.py \"$1\" \"$2\""

--- a/run_all.sh
+++ b/run_all.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-docker run --rm --link pgs_cohmetrix:pgs_cohmetrix --link palavras:palavras -v "$SCRIPT_DIR":/opt/text_metrics cohmetrix:focal bash -c "python3 run_all.py \"$1\" \"$2\""
+docker run --rm --link pgs_cohmetrix:pgs_cohmetrix --link palavras:palavras -v "$SCRIPT_DIR":/opt/text_metrics cohmetrix:noble bash -c "python3 run_all.py \"$1\" \"$2\""

--- a/run_minimal.sh
+++ b/run_minimal.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-docker run --rm --link pgs_cohmetrix:pgs_cohmetrix -v "$SCRIPT_DIR":/opt/text_metrics cohmetrix:focal bash -c "python3 run_min.py \"$1\" \"$2\""
+docker run --rm --link pgs_cohmetrix:pgs_cohmetrix -v "$SCRIPT_DIR":/opt/text_metrics cohmetrix:noble bash -c "python3 run_min.py \"$1\" \"$2\""

--- a/run_profile.sh
+++ b/run_profile.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker run --rm --link pgs_cohmetrix:pgs_cohmetrix -v /home/alefa/nilcmetrix:/opt/text_metrics cohmetrix:focal bash -c "python3 run_profiled.py \"$1\""
+docker run --rm --link pgs_cohmetrix:pgs_cohmetrix -v /home/alefa/nilcmetrix:/opt/text_metrics cohmetrix:noble bash -c "python3 run_profiled.py \"$1\""

--- a/tests/README.md
+++ b/tests/README.md
@@ -7,7 +7,7 @@ beyond a small float tolerance.
 
 ## Requirements
 
-- Docker, with the `cohmetrix:focal` image available locally.
+- Docker, with the `cohmetrix:noble` image available locally.
 - A running Postgres container exposing the cohmetrix lexical data, linked
   into the test container as `pgs_cohmetrix`. By default the host container
   is also named `pgs_cohmetrix`; override with `--pgs-container NAME`.

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -65,5 +65,5 @@ esac
 exec docker run --rm \
     --link "${PGS_CONTAINER}:pgs_cohmetrix" \
     -v "$REPO_ROOT":/opt/text_metrics \
-    cohmetrix:focal \
+    cohmetrix:noble \
     bash -c "$INNER"


### PR DESCRIPTION
The focal->noble rename (68ed88f) updated only build.sh and Dockerfile.nilcmetrix, so build.sh now produces a cohmetrix:noble image while run*.sh and tests/run_tests.sh still try to run cohmetrix:focal -- which no longer exists. After a fresh build, ./run.sh and the test harness fail with "image not found".

Rename the remaining references so build, run, and test all agree on cohmetrix:noble: run.sh, run_all.sh, run_minimal.sh, run_profile.sh, tests/run_tests.sh, and the README mentions.